### PR TITLE
fix: 7 findings from automated code-review audit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,8 +25,13 @@ build_yaml() {
         local name; name="$(echo "${entry%%|*}" | xargs)"
         local cmd;  cmd="$(echo "${entry##*|}"  | xargs)"
         if prompt_yn "Register $name (command: '$cmd')?" n; then
-            { echo "  - name: $name"; printf "    cmd: ["; local first=1
-              for tok in $cmd; do [ $first -eq 0 ] && printf ", "; printf "\"%s\"" "$tok"; first=0; done
+            { local name_safe; name_safe="$(printf '%s' "$name" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+              echo "  - name: \"$name_safe\""; printf "    cmd: ["; local first=1
+              for tok in $cmd; do
+                [ $first -eq 0 ] && printf ", "
+                local tok_safe; tok_safe="$(printf '%s' "$tok" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+                printf '"%s"' "$tok_safe"; first=0
+              done
               printf "]\n"; echo "    timeout_s: 300"; } >> "$out"
             added=$((added+1))
         fi
@@ -35,8 +40,13 @@ build_yaml() {
         local name cmd
         name="$(prompt_default "Name" "my-llm")"
         cmd="$(prompt_default "Command (space-separated)" "my-llm -p")"
-        { echo "  - name: $name"; printf "    cmd: ["; local first=1
-          for tok in $cmd; do [ $first -eq 0 ] && printf ", "; printf "\"%s\"" "$tok"; first=0; done
+        { local name_safe; name_safe="$(printf '%s' "$name" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+          echo "  - name: \"$name_safe\""; printf "    cmd: ["; local first=1
+          for tok in $cmd; do
+            [ $first -eq 0 ] && printf ", "
+            local tok_safe; tok_safe="$(printf '%s' "$tok" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+            printf '"%s"' "$tok_safe"; first=0
+          done
           printf "]\n"; echo "    timeout_s: 300"; } >> "$out"
         added=$((added+1))
     fi

--- a/src/mesh_review/cli.py
+++ b/src/mesh_review/cli.py
@@ -81,8 +81,15 @@ def cmd_summary(args) -> int:
         print("error: provide --pr <repo>#<n> or --diff-file <path>", file=sys.stderr)
         return 2
     if args.diff_file:
-        with open(args.diff_file, encoding="utf-8") as f:
-            diff = f.read()
+        try:
+            with open(args.diff_file, encoding="utf-8") as f:
+                diff = f.read()
+        except FileNotFoundError:
+            print(f"error: diff file not found: {args.diff_file}", file=sys.stderr)
+            return 1
+        except OSError as exc:
+            print(f"error: cannot read {args.diff_file}: {exc}", file=sys.stderr)
+            return 1
     else:
         repo, _, pr = args.pr.partition("#")
         if not repo or not pr:

--- a/src/mesh_review/review/core.py
+++ b/src/mesh_review/review/core.py
@@ -114,6 +114,9 @@ def _shell_runner(cli: str, cmd: List[str], timeout: int):
         except subprocess.TimeoutExpired:
             return ReviewResult(cli=cli, findings=[], raw_output="",
                                 error=f"{cli} timeout after {timeout}s")
+        if proc.returncode != 0:
+            return ReviewResult(cli=cli, findings=[], raw_output=proc.stdout,
+                                error=f"{cli} exited {proc.returncode}: {proc.stderr.strip()[:300]}")
         out = proc.stdout
         findings = _parse_findings(out, default_cli=cli, default_file=path)
         return ReviewResult(cli=cli, findings=findings, raw_output=out)

--- a/src/mesh_review/review/falsify.py
+++ b/src/mesh_review/review/falsify.py
@@ -128,6 +128,9 @@ def make_subprocess_falsifier(
         except subprocess.TimeoutExpired:
             return {"falsified": False, "confidence": 0.0,
                     "rationale": f"{cli}: timeout after {timeout_s}s"}
+        if proc.returncode != 0:
+            return {"falsified": False, "confidence": 0.0,
+                    "rationale": f"{cli}: exited {proc.returncode}: {proc.stderr.strip()[:200]}"}
         parsed = _parse_falsifier_output(proc.stdout)
         if parsed is None:
             return {"falsified": False, "confidence": 0.0,
@@ -149,6 +152,11 @@ def _default_falsifier(cli: str, prompt: str) -> Dict:
             "rationale": f"{cli}: no falsifier supplied (use make_subprocess_falsifier)"}
 
 
+def _esc(v: object) -> str:
+    """Escape curly braces in LLM-controlled values before str.format() calls."""
+    return str(v).replace("{", "{{").replace("}", "}}")
+
+
 def sigma_gate(consensus: List[ConsensusFinding],
                falsifier: Optional[Callable[[str, str], Dict]] = None,
                clis: Optional[List[str]] = None,
@@ -168,8 +176,9 @@ def sigma_gate(consensus: List[ConsensusFinding],
     out: List[Dict] = []
     for cluster in consensus:
         prompt = _FALSIFY_PROMPT.format(
-            file=cluster.file, line=cluster.line, severity=cluster.severity,
-            title=cluster.title, body=cluster.findings[0].body if cluster.findings else "",
+            file=_esc(cluster.file), line=_esc(cluster.line),
+            severity=_esc(cluster.severity), title=_esc(cluster.title),
+            body=_esc(cluster.findings[0].body if cluster.findings else ""),
         )
         falsifications = []
         target_clis = clis or sorted(set(cluster.clis))

--- a/src/mesh_review/summary/core.py
+++ b/src/mesh_review/summary/core.py
@@ -66,7 +66,7 @@ def _shell_runner(cli: str, cmd: List[str], timeout: int):
     def run(diff: str, prompt: str) -> SummaryDoc:
         if not shutil.which(cmd[0]):
             return SummaryDoc(cli=cli, error=f"{cmd[0]} not on PATH")
-        full_prompt = prompt.format(diff=diff)
+        full_prompt = prompt.replace("{diff}", diff)
         try:
             proc = subprocess.run(
                 cmd + [full_prompt],
@@ -74,6 +74,8 @@ def _shell_runner(cli: str, cmd: List[str], timeout: int):
             )
         except subprocess.TimeoutExpired:
             return SummaryDoc(cli=cli, error=f"{cli} timeout after {timeout}s")
+        if proc.returncode != 0:
+            return SummaryDoc(cli=cli, error=f"{cli} exited {proc.returncode}: {proc.stderr.strip()[:300]}")
         return _parse_summary(cli, proc.stdout)
     return run
 


### PR DESCRIPTION
## Automated Code-Review Audit Fixes

This PR resolves 7 findings identified by automated analysis. Individual GitHub issues will track each finding.

### Changes

| # | Severity | File | Finding |
|---|----------|------|---------|
| 1 | **HIGH** | `summary/core.py` | `prompt.format(diff=diff)` crashes when diff contains `{` or `}` |
| 2 | MEDIUM | `review/core.py` | Subprocess non-zero exit silently discarded in `_shell_runner` |
| 3 | MEDIUM | `summary/core.py` | Subprocess non-zero exit silently discarded in `_shell_runner` |
| 4 | MEDIUM | `review/falsify.py` | Subprocess non-zero exit silently discarded in `make_subprocess_falsifier` |
| 5 | MEDIUM | `review/falsify.py` | LLM-controlled values passed unescaped to `str.format()` in `sigma_gate` |
| 6 | MEDIUM | `cli.py` | `open(args.diff_file)` unhandled `FileNotFoundError`/`OSError` |
| 7 | LOW | `install.sh` | YAML injection via unescaped `$name`/`$tok` in `build_yaml()` |

### Fix details

**Finding 1 (HIGH) — `summary/core.py`:** The default prompt template contains `{diff}` which was expanded with `prompt.format(diff=diff)`. Any diff containing a literal `{word}` (e.g., `{HEAD}` in git conflict markers, JSON payloads, Python f-strings) raises `KeyError` or `ValueError`, crashing the summarization for all CLIs. Fixed by switching to `prompt.replace("{diff}", diff)`.

**Findings 2–4 (MEDIUM) — subprocess returncode ignored:** `_shell_runner` in both `review/core.py` and `summary/core.py`, and `make_subprocess_falsifier` in `falsify.py`, call `subprocess.run()` but never check `proc.returncode`. A non-zero exit (auth error, missing model, rate-limit) causes the error to be silently treated as LLM output, polluting findings or producing garbage summaries. Fixed by returning an error result immediately on non-zero exit.

**Finding 5 (MEDIUM) — `falsify.py:sigma_gate`:** `_FALSIFY_PROMPT.format(...)` is called with LLM-controlled values (finding title, body) as kwargs. Any value containing `{` or `}` (e.g., a finding about JSON handling) raises `KeyError`/`ValueError`. Added `_esc()` helper that doubles braces before passing to `.format()`.

**Finding 6 (MEDIUM) — `cli.py`:** `open(args.diff_file)` was unguarded; a missing or unreadable file raises `FileNotFoundError`/`OSError` with a Python traceback. Wrapped in `try/except` with a clean `error: ...` message to `stderr` and exit code 1.

**Finding 7 (LOW) — `install.sh`:** `build_yaml()` wrote user-supplied `$name` and `$tok` values directly into YAML strings without quoting or escaping. A name like `my:llm` breaks YAML mapping structure; a token like `my"arg` breaks the YAML double-quoted string. Fixed by wrapping all values in YAML double quotes and escaping `\` → `\\` and `"` → `\"` via `sed`.